### PR TITLE
1. Restore documents to correct position to begin with instead of ope…

### DIFF
--- a/src/Commands/CmdSession.cpp
+++ b/src/Commands/CmdSession.cpp
@@ -31,7 +31,6 @@
 #include "ProgressDlg.h"
 #include "SysInfo.h"
 #include "AppUtils.h"
-#include "MainWindow.h"
 
 #include <sstream>
 #include <string>
@@ -261,7 +260,7 @@ void CCmdSessionLoad::RestoreSavedSession()
         restoreData.m_tabSpace = (TabSpace)settings.GetInt64(sessionSection(), CStringUtils::Format(L"tabspace%d", fileNum).c_str(), 0);
         restoreData.m_readDir = (ReadDirection)settings.GetInt64(sessionSection(), CStringUtils::Format(L"readdir%d", fileNum).c_str(), 0);
 
-        int tabIndex = m_pMainWindow->OpenFile(path.c_str(), openflags, &restoreData);
+        int tabIndex = OpenFile(path.c_str(), openflags, &restoreData);
         if (tabIndex < 0)
             continue;
         // Don't use the index to track the active tab, as it's probably

--- a/src/Commands/CommandHandler.cpp
+++ b/src/Commands/CommandHandler.cpp
@@ -105,6 +105,7 @@ ICommand* CCommandHandler::GetCommand(UINT cmdId)
 
 void CCommandHandler::Init(void* obj)
 {
+    ICommand* cmd = nullptr;
     Add<CCmdMRU>(obj);
     Add<CCmdToggleTheme>(obj);
     Add<CCmdOpen>(obj);
@@ -135,8 +136,10 @@ void CCommandHandler::Init(void* obj)
     Add<CCmdSelectAll>(obj);
     Add<CCmdGotoBrace>(obj);
     Add<CCmdConfigShortcuts>(obj);
-    Add<CCmdLineWrap>(obj);
-    Add<CCmdLineWrapIndent>(obj);
+    cmd = Add<CCmdLineWrap>(obj);
+    m_loadfirstcommands.push_back(cmd);
+    cmd = Add<CCmdLineWrapIndent>(obj);
+    m_loadfirstcommands.push_back(cmd);
     Add<CCmdWhiteSpace>(obj);
     Add<CCmdLineNumbers>(obj);
     Add<CCmdUseTabs>(obj);
@@ -339,9 +342,13 @@ void CCommandHandler::OnClipboardChanged()
 
 void CCommandHandler::BeforeLoad()
 {
+    for (auto& cmd : m_loadfirstcommands)
+        cmd->BeforeLoad();
     for (auto& cmd : m_commands)
     {
-        cmd.second->BeforeLoad();
+        auto whereAt = std::find(m_loadfirstcommands.begin(), m_loadfirstcommands.end(), cmd.second.get());
+        if (whereAt == m_loadfirstcommands.end())
+            cmd.second->BeforeLoad();
     }
     for (auto& cmd : m_nodeletecommands)
     {

--- a/src/Commands/CommandHandler.h
+++ b/src/Commands/CommandHandler.h
@@ -81,6 +81,7 @@ private:
     }
 
     std::map<UINT, std::unique_ptr<ICommand>> m_commands;
+    std::vector<ICommand*>                    m_loadfirstcommands;
     std::map<UINT, ICommand*>                 m_nodeletecommands;
     std::map<UINT, std::wstring>              m_plugins;
     std::map<std::wstring, int>               m_pluginversion;

--- a/src/Commands/ICommand.cpp
+++ b/src/Commands/ICommand.cpp
@@ -178,9 +178,9 @@ HWND ICommand::GetScintillaWnd() const
     return m_pMainWindow->m_editor;
 }
 
-int ICommand::OpenFile(LPCWSTR file, unsigned int openFlags)
+int ICommand::OpenFile(LPCWSTR file, unsigned int openFlags, CDocumentRestoreData* restoreData)
 {
-    return m_pMainWindow->OpenFile(file, openFlags);
+    return m_pMainWindow->OpenFile(file, openFlags, restoreData);
 }
 
 void ICommand::OpenFiles(const std::vector<std::wstring>& paths)

--- a/src/Commands/ICommand.h
+++ b/src/Commands/ICommand.h
@@ -127,7 +127,7 @@ protected:
     HWND                GetHwnd() const;
     HWND                GetScintillaWnd() const;
     UINT                GetTimerID() { return m_nextTimerID++; }
-    int                 OpenFile(LPCWSTR file, unsigned int openFlags);
+    int                 OpenFile(LPCWSTR file, unsigned int openFlags, CDocumentRestoreData* restoreData = nullptr);
     void                OpenFiles(const std::vector<std::wstring>& paths);
     void                OpenHDROP(HDROP hDrop);
     bool                ReloadTab(int tab, int encoding = -1); // By default reload encoding

--- a/src/Document.h
+++ b/src/Document.h
@@ -72,6 +72,15 @@ public:
     sptr_t              m_lastStyleLine;
 };
 
+struct CDocumentRestoreData
+{
+    std::wstring  m_originalPath;
+    std::wstring  m_originalTitle;
+    CPosData      m_position;
+    TabSpace      m_tabSpace;
+    ReadDirection m_readDir;
+};
+
 class CDocument
 {
 public:

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -74,7 +74,7 @@ public:
     bool CreateRibbon();
 
     // Load/Reload functions
-    int  OpenFile(const std::wstring& file, unsigned int openFlags);
+    int  OpenFile(const std::wstring& file, unsigned int openFlags, CDocumentRestoreData* restoreData = nullptr);
     bool OpenFileAs(const std::wstring& temppath, const std::wstring& realpath, bool bModified);
     bool ReloadTab(int tab, int encoding, bool dueToOutsideChanges = false);
 

--- a/src/ScintillaWnd.cpp
+++ b/src/ScintillaWnd.cpp
@@ -899,7 +899,8 @@ void CScintillaWnd::RestoreCurrentPos(const CPosData& pos)
     }
     Call(SCI_CHOOSECARETX);
 
-    Call(SCI_ENSUREVISIBLE, pos.m_nFirstVisibleLine);
+    if (Call(SCI_GETLINEVISIBLE, pos.m_nFirstVisibleLine) == 0)
+        Call(SCI_ENSUREVISIBLE, pos.m_nFirstVisibleLine);
     auto lineToShow = Call(SCI_VISIBLEFROMDOCLINE, pos.m_nFirstVisibleLine);
     if (wrapmode != SC_WRAP_NONE)
     {

--- a/src/ScintillaWnd.h
+++ b/src/ScintillaWnd.h
@@ -156,9 +156,6 @@ private:
     int                     m_cursorTimeout;
     bool                    m_bInFolderMargin;
     bool                    m_hasConsolas;
-    sptr_t                  m_LineToScrollToAfterPaint;
-    sptr_t                  m_WrapOffsetToScrollToAfterPaint;
-    int                     m_LineToScrollToAfterPaintCounter;
     AnimationVariable       m_animVarGrayFore;
     AnimationVariable       m_animVarGrayBack;
     AnimationVariable       m_animVarGraySel;


### PR DESCRIPTION
…nning at start then moving to correct position. This prevents significant flickering and should be quicker. Remove wrapping work around code that seems uneccessary. 2. Try to address perceived issues with backup/restore in event of file existence errors. 3. Don't activate current tab twice. Please test all of this very carefully, not to be rushed into release.

This is a significant change to address the main document painting issues I have with bowpad - which is that it paints the first screen of a document and then repaints the screen again with the actual position it wants to restore to. If you use MainWindow.cpp as an example, by going to the end of the document and restarting, you should see the comments section of the file appear then vanish as bowpad repaints the end section. This patch aims to fix that problem.

The changes in this patch touch the cursor handling and backup/restore stuff so it needs careful testing as I'm not claiming to really understand scintilla etc. or the backup code well. The patch *seems* to work against some initial testing I've done, but the patch is as much to demonstrate the problem and example solution to that.

However the file opening logic in bowpad is complicated and really needs to be refactored so it is more maintainable and less fragile. Recent support for backups has made the code even more complicated. Personally, I wonder if the backup feature should be dropped to keep things simpler and reintroduced later under a better model or something. Or even not, as I find work using the backup files a questionable work flow anyway.

I think pondering how this file opening code works in more scenarios is necessary and with a view to a simpler model. But for now this patch offers something to play with that demonstrates the issue and a possible solution to test with.